### PR TITLE
Support dynamic package version

### DIFF
--- a/generators/src/main/java/com/pdc/SemVerUtils.java
+++ b/generators/src/main/java/com/pdc/SemVerUtils.java
@@ -1,0 +1,46 @@
+package com.pdc;
+
+public class SemVerUtils {
+	public static String combineSemVer(String versionA, String versionB) {
+		SemVer semVerA = parseSemVer(versionA);
+		SemVer semVerB = parseSemVer(versionB);
+
+		if (semVerA.major == 0 || semVerB.major == 0) {
+			int combinedMinor = semVerA.major + semVerB.major + semVerA.minor + semVerB.minor;
+			int combinedPatch = semVerA.patch + semVerB.patch;
+			return "0." + combinedMinor + "." + combinedPatch;
+		} else {
+			int combinedMajor = semVerA.major + semVerB.major;
+			int combinedMinor = semVerA.minor + semVerB.minor;
+			int combinedPatch = semVerA.patch + semVerB.patch;
+			return combinedMajor + "." + combinedMinor + "." + combinedPatch;
+		}
+	}
+
+	private static SemVer parseSemVer(String version) {
+		String[] parts = version.split("\\.");
+		if (parts.length < 3) {
+			throw new IllegalArgumentException("Invalid SemVer string: " + version);
+		}
+		int major = Integer.parseInt(parts[0]);
+		int minor = Integer.parseInt(parts[1]);
+		int patch = Integer.parseInt(parts[2]);
+		return new SemVer(major, minor, patch);
+	}
+
+	private static class SemVer {
+		int major;
+		int minor;
+		int patch;
+
+		public SemVer(int major, int minor, int patch) {
+			this.major = major;
+			this.minor = minor;
+			this.patch = patch;
+		}
+
+		public String toString() {
+			return this.major + "." + this.minor + "." + this.patch;
+		}
+	}
+}

--- a/generators/src/main/java/io/swagger/codegen/v3/generators/typescript/TypescriptGenerator.java
+++ b/generators/src/main/java/io/swagger/codegen/v3/generators/typescript/TypescriptGenerator.java
@@ -1,11 +1,15 @@
 package io.swagger.codegen.v3.generators.typescript;
 
+import com.pdc.SemVerUtils;
 import io.swagger.codegen.v3.SupportingFile;
+import io.swagger.v3.oas.models.OpenAPI;
+
 import java.io.File;
 
 public class TypescriptGenerator extends AbstractTypeScriptClientCodegen {
 	protected String sourceFolder = "src";
 	protected String templateVersion = "0.0.1";
+	protected String packageVersion = "";
 
 	/**
 	 * Configures a friendly name for the generator.  This will be used by the generator
@@ -42,9 +46,21 @@ public class TypescriptGenerator extends AbstractTypeScriptClientCodegen {
 		supportingFiles.add(new SupportingFile("types/index.mustache", "", "src/types/index.ts"));
 
 		// We want the package / lock files to be detectable and maintained by dependabot.
-		// This means they cannot be templates, since dependabot expects a specific name.
-		supportingFiles.add(new SupportingFile("package.json", "", "package.json"));
-		supportingFiles.add(new SupportingFile("package-lock.json", "", "package-lock.json"));
+		// We also want the files to be interpreted as templates.
+		// Both of these requirements are driven by file name, which is why we are using symlinks.
+		supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
+		supportingFiles.add(new SupportingFile("package-lock.mustache", "", "package-lock.json"));
+
+	}
+
+	@Override
+	public void preprocessOpenAPI(OpenAPI openAPI) {
+		super.preprocessOpenAPI(openAPI);
+		this.packageVersion = SemVerUtils.combineSemVer(
+			this.templateVersion,
+			openAPI.getInfo().getVersion()
+		).toString();
+		additionalProperties.put("packageVersion", this.packageVersion);
 	}
 
 	@Override

--- a/generators/src/main/resources/typescript/package-lock.json
+++ b/generators/src/main/resources/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdc/sdk",
-  "version": "0.0.0",
+  "version": "{{packageVersion}}",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/generators/src/main/resources/typescript/package-lock.mustache
+++ b/generators/src/main/resources/typescript/package-lock.mustache
@@ -1,0 +1,1 @@
+package-lock.json

--- a/generators/src/main/resources/typescript/package.json
+++ b/generators/src/main/resources/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdc/sdk",
-  "version": "0.0.0",
+  "version": "{{packageVersion}}",
   "description": "A swagger client for the Philanthropy Data Commons (PDC)",
   "author": "Open Tech Strategies",
   "keywords": [

--- a/generators/src/main/resources/typescript/package.mustache
+++ b/generators/src/main/resources/typescript/package.mustache
@@ -1,0 +1,1 @@
+package.json


### PR DESCRIPTION
This PR adds support for dynamically populated version numbers for the typescript package.  This will make publication to NPM more predictable (and maintain semver).

Resolves #9 