### PR TITLE
Migrate to OpenAPI Generator

### DIFF
--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.56'
+	implementation 'org.openapitools:openapi-generator-cli:7.6.0'
 }

--- a/generators/src/main/java/org/openapitools/codegen/languages/TypescriptGenerator.java
+++ b/generators/src/main/java/org/openapitools/codegen/languages/TypescriptGenerator.java
@@ -1,9 +1,9 @@
-package io.swagger.codegen.v3.generators.typescript;
 
+package org.openapitools.codegen.languages;
+
+import org.openapitools.codegen.*;
 import com.pdc.SemVerUtils;
-import io.swagger.codegen.v3.SupportingFile;
 import io.swagger.v3.oas.models.OpenAPI;
-
 import java.io.File;
 
 public class TypescriptGenerator extends AbstractTypeScriptClientCodegen {
@@ -11,29 +11,22 @@ public class TypescriptGenerator extends AbstractTypeScriptClientCodegen {
 	protected String templateVersion = "0.0.1";
 	protected String packageVersion = "";
 
-	/**
-	 * Configures a friendly name for the generator.  This will be used by the generator
-	 * to select the library with the -l flag.
-	 *
-	 * @return the friendly name for the generator
-	 */
+	public CodegenType getTag() {
+			return CodegenType.CLIENT;
+	}
+
 	public String getName() {
 		return "typescript";
 	}
 
-	/**
-	 * Returns human-friendly help for the generator.  Provide the consumer with help
-	 * tips, parameters here
-	 *
-	 * @return A string value for the help message
-	 */
 	public String getHelp() {
 		return "Generates a typescript client library.";
 	}
 
 	public TypescriptGenerator() {
 		super();
-		outputFolder = "build/typescript";
+		outputFolder = "build" + File.separator + "typescript";
+		embeddedTemplateDir = templateDir = "typescript";
 		modelTemplateFiles.put(
 			"types/type.mustache",
 			".ts"
@@ -65,26 +58,11 @@ public class TypescriptGenerator extends AbstractTypeScriptClientCodegen {
 
 	@Override
 	public String modelFileFolder() {
-		return outputFolder + "/" + sourceFolder + "/types/" + modelPackage().replace('.', File.separatorChar);
+		return outputFolder + File.separator + sourceFolder + File.separator + "types"  + File.separator + modelPackage().replace('.', File.separatorChar);
 	}
 
 	@Override
 	public String apiFileFolder() {
-		return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
-	}
-
-	@Override
-	public String getArgumentsLocation() {
-		return null;
-	}
-
-	@Override
-	public String getDefaultTemplateDir() {
-		return "typescript";
-	}
-
-	@Override
-	public String getTemplateDir() {
-		return "typescript";
+		return outputFolder + File.separator + sourceFolder + File.separator + apiPackage().replace('.', File.separatorChar);
 	}
 }

--- a/generators/src/main/resources/META-INF/services/io.swagger.codegen.v3.CodegenConfig
+++ b/generators/src/main/resources/META-INF/services/io.swagger.codegen.v3.CodegenConfig
@@ -1,1 +1,0 @@
-io.swagger.codegen.v3.generators.typescript.TypescriptGenerator

--- a/generators/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
+++ b/generators/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
@@ -1,0 +1,1 @@
+org.openapitools.codegen.languages.TypescriptGenerator

--- a/generators/src/main/resources/typescript/types/type.mustache
+++ b/generators/src/main/resources/typescript/types/type.mustache
@@ -9,7 +9,7 @@ import { Writable } from './Writable';
 	{{#model}}
 export interface {{classname}} {
 		{{#vars}}
-	{{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+	{{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
 		{{/vars}}
 }
 


### PR DESCRIPTION
This PR moves the sdk tools to use [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) instead of Swagger Codegen.  OpenAPI Generator is a community fork, and is much more actively maintained.  This move will allow future SDK builds to benefit from some bug fixes in the spec mapping to types, as well as support version 3.1 in future (see https://github.com/PhilanthropyDataCommons/service/pull/854)

Resolves #25

You should be able to test this by following the README to generate the SDK -- check out the `PlatformDataProviderResponse` type and notice how `data` is an `object` rather than `any` 🎉 