### PR TITLE
Upgrade Gradle from 8.3 to 8.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Alongside security updates, perhaps the most notable improvement is the support for the current LTS release of Java, Java 21, introduced with 8.4 and 8.5.

- https://docs.gradle.org/8.4/release-notes.html
- https://docs.gradle.org/8.5/release-notes.html
- https://docs.gradle.org/8.6/release-notes.html
- https://docs.gradle.org/8.7/release-notes.html
- https://docs.gradle.org/8.8/release-notes.html
- https://docs.gradle.org/8.9/release-notes.html