### PR TITLE
Check for Gradle updates weekly

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * Mon"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
Use the [Update Gradle Wrapper Action](https://github.com/marketplace/actions/update-gradle-wrapper-action) to periodically check for new versions of Gradle, and open a PR to update the wrapper when a new version is available.

This is a workaround until [dependabot support](https://github.com/dependabot/dependabot-core/issues/2223) is implemented.

I don't think we'll be able to test this until a new version comes out.

Follow-up to @slifty's suggestion in https://github.com/PhilanthropyDataCommons/sdk/pull/30#pullrequestreview-2217248195.