### PR TITLE
Specify the service repo in the manifest

### DIFF
--- a/generators/src/main/resources/typescript/package.json
+++ b/generators/src/main/resources/typescript/package.json
@@ -18,5 +18,9 @@
 		"@tsconfig/node18": "^18.2.2",
 		"rimraf": "^5.0.5",
 		"typescript": "^5.3.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PhilanthropyDataCommons/service.git"
   }
 }


### PR DESCRIPTION
The reason for this is we build the actual SDK in a service repo action and npmjs.com expects it to come from a service repo action.

Issue https://github.com/PhilanthropyDataCommons/service/issues/2170