### PR TITLE
Generate top-level enum schemas as export enum, not empty interfaces

### DIFF
--- a/generators/src/main/resources/typescript/types/type.mustache
+++ b/generators/src/main/resources/typescript/types/type.mustache
@@ -7,27 +7,40 @@ import { Writable } from './Writable';
 
 {{#models}}
 	{{#model}}
+		{{#isEnum}}
+export enum {{classname}} {
+			{{#allowableValues}}
+				{{#enumVars}}
+	{{{name}}} = {{{value}}}{{^@last}},{{/@last}}
+				{{/enumVars}}
+			{{/allowableValues}}
+}
+
+export type Writable{{classname}} = Writable<{{classname}}>;
+		{{/isEnum}}
+		{{^isEnum}}
 export interface {{classname}} {
-		{{#vars}}
+			{{#vars}}
 	{{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
-		{{/vars}}
+			{{/vars}}
 }
 
 export type Writable{{classname}} = Writable<{{classname}}>
 
-		{{#hasEnums}}
+			{{#hasEnums}}
 export namespace {{classname}} {
-			{{#vars}}
-				{{#isEnum}}
+				{{#vars}}
+					{{#isEnum}}
 	export enum {{enumName}} {
-					{{#allowableValues}}
-						{{#enumVars}}
+						{{#allowableValues}}
+							{{#enumVars}}
 		{{{name}}} = {{{value}}}{{^@last}},{{/@last}}
-						{{/enumVars}}
-					{{/allowableValues}}
+							{{/enumVars}}
+						{{/allowableValues}}
 	}
-				{{/isEnum}}
-			{{/vars}}
+					{{/isEnum}}
+				{{/vars}}
 }{{/hasEnums}}
+		{{/isEnum}}
 	{{/model}}
 {{/models}}


### PR DESCRIPTION
Top-level enum schemas were generating as empty interfaces because type.mustache only handled enums as properties. The fix adds handling for enums as models.

Template fix sourced from https://github.com/OpenAPITools/openapi-generator/pull/2266

Closes #40 

Related to https://github.com/PhilanthropyDataCommons/service/issues/2353